### PR TITLE
added on:change event

### DIFF
--- a/src/Calendar.svelte
+++ b/src/Calendar.svelte
@@ -29,6 +29,11 @@
   import CalendarHader from "./Selector/Selector.svelte";
   import CalendarBody from "./body/CalendarBody.svelte";
   import "./fix-date.js";
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
+  let changed = 0;
 
   /**
    * Set base date
@@ -117,7 +122,8 @@
     disabled: disabled,
     selected: selected,
     focused: marked,
-    pickerDone: pickerDone
+    pickerDone: pickerDone,
+    changed: changed
   });
 
   setContext("praecoxCalendarData", praecoxCalendarData);
@@ -128,6 +134,11 @@
     selected = $praecoxCalendarConfig.selected;
     pickerDone = $praecoxCalendarConfig.pickerDone;
   });
+
+  $: if( $praecoxCalendarData.changed > changed ) {
+    changed = $praecoxCalendarData.changed;
+    dispatch('change', $praecoxCalendarData.selected);
+  }
 </script>
 
 <style>

--- a/src/body/CalendarBodyDay.svelte
+++ b/src/body/CalendarBodyDay.svelte
@@ -69,6 +69,8 @@
     if ($praecoxCalendar.pickerMode == "free") {
       freePicker(day);
     }
+
+    $praecoxCalendar.changed += 1;
   }
 
   function testSelectedRange(n) {


### PR DESCRIPTION
In addition to bind:selected approach I'd like to have "change" event that fires within the pick function.
```
<script>
  import Datepicker from "praecox-datepicker";

  let current_date;

  const handleChangeDate = e => current_date = new Date(e.detail);

  $: console.log(current_date)

</script>

<Datepicker on:change={ handleChangeDate } />
```
