### PR TITLE
Reload disabled dates on left/right click

### DIFF
--- a/src/Calendar.svelte
+++ b/src/Calendar.svelte
@@ -107,6 +107,12 @@
    */
   export let pickerDone = false;
 
+  /**
+   * External function that get used to reload the disabled array on Next/Prev action
+   *
+  */
+  export let reloadDisabled;
+
   const praecoxCalendarData = writable({
     nowDate: [],
     viewDate: viewDate,
@@ -123,7 +129,12 @@
     selected: selected,
     focused: marked,
     pickerDone: pickerDone,
-    changed: changed
+    changed: changed,
+    reloadDisabled: () => {
+      if( typeof reloadDisabled == 'function' ) {
+        $praecoxCalendarData.disabled = reloadDisabled(getThisMonthData($praecoxCalendarData.viewDate).flat());
+      }
+    }
   });
 
   setContext("praecoxCalendarData", praecoxCalendarData);
@@ -134,6 +145,8 @@
     selected = $praecoxCalendarConfig.selected;
     pickerDone = $praecoxCalendarConfig.pickerDone;
   });
+
+  $praecoxCalendarData.reloadDisabled();
 
   $: if( $praecoxCalendarData.changed > changed ) {
     changed = $praecoxCalendarData.changed;

--- a/src/Selector/Next.svelte
+++ b/src/Selector/Next.svelte
@@ -14,6 +14,7 @@
     switch ($praecoxCalendar.view) {
       case "month":
         $praecoxCalendar.viewDate = `${ny}-${nm}-${td}`;
+        $praecoxCalendar.reloadDisabled();
         break;
       case "year":
         $praecoxCalendar.viewDate = `${ty + 1}-${tm}-${td}`;

--- a/src/Selector/Prev.svelte
+++ b/src/Selector/Prev.svelte
@@ -13,6 +13,7 @@
     switch ($praecoxCalendar.view) {
       case "month":
         $praecoxCalendar.viewDate = `${py}-${pm}-${td}`;
+        $praecoxCalendar.reloadDisabled();
         break;
       case "year":
         $praecoxCalendar.viewDate = `${ty - 1}-${tm}-${td}`;


### PR DESCRIPTION
I would like to be able to arbitrarily change the disabled dates for any month. For example, disable all Mondays in May, and all Saturdays in June. For example, I want to disable all odd dates 

```
  const reloadDisabled = dates => {
    const arr = [];

    for(let i=0, len=dates.length; i < len; i++) {
      if( i % 2 ) {
        arr.push(`${dates[i].getFullYear()}-${dates[i].getMonth() + 1}-${dates[i].getDate()}`);
      }
    }
    return arr;
  }

<Datepicker
    {reloadDisabled}
/>
```
![image](https://user-images.githubusercontent.com/524100/125536704-d99eeb79-e65c-4a5f-aef6-042028c28393.png)
