### PR TITLE
reload disabled fix

### DIFF
--- a/src/Calendar.svelte
+++ b/src/Calendar.svelte
@@ -111,7 +111,7 @@
    * External function that get used to reload the disabled array on Next/Prev action
    *
    */
-  let reloadDisabled = undefined;
+  export let reloadDisabled = undefined;
 
   /**
    * Used to show/hide to the FinishBtn button

--- a/src/body/CalendarBodyWeek.svelte
+++ b/src/body/CalendarBodyWeek.svelte
@@ -24,6 +24,8 @@
           ) {
             return true;
           }
+        } else if( arrItem instanceof Date && arrItem.getTime() == thisDate ) {
+            return true;
         } else {
           for (let i = 0; i < arrItem.length; i++) {
             if (new Date(arrItem[i]).getTime() == thisDate) {


### PR DESCRIPTION
I see that $praecoxCalendar.reloadDisabled() is already added to CalendarBodyYear )))) 

It is also highly desirable to pass filtered dates, not strings (like '2021-7-16'), because string comparison does not work correctly for now (see [REPL](https://svelte.dev/repl/d735b70561da4870ae7c1d944d9c5fa4?version=3.29.0))

```
  const reloadDisabled = dates => {
    const arr = [];

    for(let i=0, len=dates.length; i < len; i++) {
      if( i % 2 ) {
        arr.push(dates[i]);
      }
    }
    return arr;
  }

<Datepicker
    {reloadDisabled}
/>
```